### PR TITLE
Make Linear algorithm sort tallest to shortest, rather than widest to…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dagmike/bin-packing",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "2D bin packing PHP implementation",
     "type": "library",
     "license": "MIT",

--- a/src/Algorithms/Linear.php
+++ b/src/Algorithms/Linear.php
@@ -28,7 +28,8 @@ class Linear
                 if ($freeRect->getWidth() >= $rectangle->getWidth()) {
                     $bestNode->setX($freeRect->getX());
                     $bestNode->setY($freeRect->getY());
-                    $bestX = $freeRect->getWidth() - $rectangle->getWidth();
+                    // Favour the tallest items first.
+                    $bestY = $freeRect->getHeight() - $rectangle->getHeight();
                     return $bestNode;
                 }
             }


### PR DESCRIPTION
See #8 .. very simple tweak to change the ordering of items in the Linear algorithm.

I've also updated composer.json with new version number 1.7.2.