### PR TITLE
Bump version to 1.7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dagmike/bin-packing",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "description": "2D bin packing PHP implementation",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
Fixes #13 
The recent merge of PR #12 didn't create a tag for the intended version 1.7.2, apparently because this was created back in 2021.  I should have set the version to 1.7.3.
![Selection_111](https://user-images.githubusercontent.com/266415/175939771-227b6e4e-61c4-492c-ab8d-fad5114bd201.jpg)

